### PR TITLE
remove call to createDirectory which throws IOException, fixes #1

### DIFF
--- a/src/main/java/com/github/connollyst/jolt/JoltRunner.java
+++ b/src/main/java/com/github/connollyst/jolt/JoltRunner.java
@@ -54,7 +54,6 @@ public class JoltRunner {
             if (createIfMissing) {
                 log.info("Creating " + filePath);
                 Files.createDirectories(Paths.get(filePath));
-                Files.createDirectory(Paths.get(filePath));
                 return asPath(filePath, false);
             } else {
                 throw new IOException("File not found: " + filePath);


### PR DESCRIPTION
Hi Sean! Thanks for making this plugin, it's saved me a lot of time :)

I made a couple of changes to get it working better for me, I'll open them as individual PRs so you can take them if you think they're useful.

This PR fixes an exception I was getting with clean builds, [described here](https://github.com/ocadotechnology/jolt-maven-plugin/issues/1)