### PR TITLE
get AbstractMojo logger after class construction, fixes #3

### DIFF
--- a/src/main/java/com/github/connollyst/jolt/JoltMojo.java
+++ b/src/main/java/com/github/connollyst/jolt/JoltMojo.java
@@ -3,7 +3,6 @@ package com.github.connollyst.jolt;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
@@ -12,8 +11,6 @@ import org.apache.maven.plugins.annotations.Parameter;
  */
 @Mojo(name = "transform")
 public class JoltMojo extends AbstractMojo {
-
-    private final Log log = getLog();
 
     @Parameter(property = "jolt.transform.specFile", defaultValue = "${project.basedir}/src/main/resources/jolt.json/")
     private String specFile;
@@ -25,7 +22,7 @@ public class JoltMojo extends AbstractMojo {
     private boolean minify;
 
     public void execute() throws MojoExecutionException, MojoFailureException {
-        JoltRunner jolt = new JoltRunner(log, specFile, inputDirectory, outputDirectory, minify);
+        JoltRunner jolt = new JoltRunner(getLog(), specFile, inputDirectory, outputDirectory, minify);
         jolt.verify();
         jolt.execute();
     }


### PR DESCRIPTION
The plugin logs at a different level to the maven logger; because `getLog` is called before the Mojo is constructed, it gets handed a default logger, instead of the maven logger.

I've described it in [this issue](https://github.com/ocadotechnology/jolt-maven-plugin/issues/3).

This PR just moves the assignment of the logger.